### PR TITLE
Added CanUseItems, to check whether the unit is muted or not

### DIFF
--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -274,6 +274,29 @@
         }
 
         /// <summary>
+        ///     Checks if given unit is not muted
+        /// </summary>
+        /// <param name="unit"></param>
+        /// <returns></returns>
+        public static bool CanUseItems( this Unit unit ) 
+        {
+            return !IsStunned( unit ) && 
+                    unit.IsAlive && 
+                   !unit.Modifiers.Any( x =>
+                            x.Name == "modifier_sheepstick_debuff" ||
+                            x.Name == "modifier_doom_bringer_doom" ||
+                            x.Name == "modifier_legion_commander_duel" ||
+                            x.Name == "modifier_tusk_snowball_movement" ||
+                            x.Name == "modifier_tusk_snowball_movement_friendly" ||
+                            x.Name == "modifier_enigma_black_hole_pull" ||
+                            ( x.Name == "modifier_disruptor_static_storm" &&
+                                ObjectMgr.GetEntities<Hero>().Where(
+                                        y => y.ClassID == ClassID.CDOTA_Unit_Hero_Disruptor
+                                    ).First().Modifiers.Any( z => z.Name == "modifier_item_ultimate_scepter" )
+                                ) );
+        }
+
+        /// <summary>
         ///     Checks if given unit can become invisible
         /// </summary>
         /// <param name="unit"></param>


### PR DESCRIPTION
I coud not find this implemented anywhere else, so here it is.

One important thing to not is that this checks if the unit can use OR Shift queue items. 

Example: If you are Cycloned, you cannot use items right now, but you can still shift queue their use. This is different from MUTE from abilities like Doom, where you cannot shift queue item usage.

My implementation checks if you are MUTED.
