### PR TITLE
CanDie() fix

### DIFF
--- a/Extensions/EntityExtensions.cs
+++ b/Extensions/EntityExtensions.cs
@@ -306,9 +306,9 @@ namespace Ensage.Common.Extensions
             return (!ignoreReincarnation && !unit.CanReincarnate())
                    && !unit.Modifiers.Any(
                        x =>
-                       (!cullingBlade && x.Name == "modifier_dazzle_shallow_grave")
-                       || x.Name == "modifier_skeleton_king_reincarnation_scepter_active"
-                       || x.Name == "modifier_oracle_purifying_flames");
+                       (!cullingBlade && (x.Name == "modifier_dazzle_shallow_grave"
+                           || x.Name == "modifier_oracle_false_promise"))
+                       || x.Name == "modifier_skeleton_king_reincarnation_scepter_active");
         }
 
         /// <summary>


### PR DESCRIPTION
Orcale ult is "modifier_oracle_false_promise" and he can be killed by axe.

I think winter ult
"modifier_winter_wyvern_winters_curse_aura"
"modifier_winter_wyvern_winters_curse"
Should be added here too and removed from damage reduction, cuz "Winter's Curse primary and secondary units are now immune to all damage from their enemies" but they can be killed by axe.

And since u added culling blade check, then how about adding abaddons not just modifier, but ult ready check, cuz if he have ult u cant kill him.
